### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ cd go-vncdriver
 ./build.sh
 ```
 
+if you get some issue like below then you can go ahead [Dependencies](https://github.com/baoblackcoal/go-vncdriver#dependencies):
+```
+fatal error: X11/Xcursor/Xcursor.h: No such file or directory
+fatal error: X11/extensions/Xrandr.h: No such file or directory
+fatal error: X11/extensions/XInput.h: No such file or directory
+fatal error: GL/gl.h: No such file or directory
+```
+
 Once you've fixed the issue, you should reinstall `go-vncdriver` via
 `pip install --ignore-installed go-vncdriver`.
 


### PR DESCRIPTION
I think this change will be useful for the issue that I have mentioned at https://github.com/openai/universe/issues/194

====================
when I run `./build.sh`get error:

```
Env info:

export CGO_LDFLAGS='/usr/lib/x86_64-linux-gnu/libjpeg.so -L/home/vnpy/anaconda2/lib -lpython2.7'
export CGO_CFLAGS='-I/home/vnpy/anaconda2/lib/python2.7/site-packages/numpy/core/include -I/home/vnpy/anaconda2/include/python2.7'

Running build with OpenGL rendering.
Building with OpenGL: go build -buildmode=c-shared -o go_vncdriver.so. (Set GO_VNCDRIVER_NOGL to build without OpenGL.)
# github.com/openai/go-vncdriver/vendor/github.com/go-gl/glfw/v3.2/glfw
In file included from glfw/src/internal.h:163:0,
                 from glfw/src/context.c:28,
                 from vendor/github.com/go-gl/glfw/v3.2/glfw/c_glfw.go:4:
glfw/src/x11_platform.h:36:22: fatal error: X11/Xlib.h: No such file or directory
compilation terminated.
# github.com/openai/go-vncdriver/vendor/github.com/go-gl/gl/v2.1/gl
vendor/github.com/go-gl/gl/v2.1/gl/procaddr.go:52:21: fatal error: GL/glx.h: No such file or directory
compilation terminated.

Note: could not build with OpenGL rendering (cf https://github.com/openai/go-vncdriver). This is expected on most servers. Going to try building without OpenGL.
Building without OpenGL: go build -tags no_gl -buildmode=c-shared -o go_vncdriver.so
```

then I google for :
`fatal error: X11/Xcursor/Xcursor.h: No such file or directory`
`fatal error: X11/extensions/Xrandr.h: No such file or directory`
`fatal error: X11/extensions/XInput.h: No such file or directory`
`fatal error: GL/gl.h: No such file or directory`

Sadly,  I have been found at the end of go_vncdriver README:

```
sudo apt-get install libx11-dev libxcursor-dev libxrandr-dev \
  libxinerama-dev libxi-dev libxxf86vm-dev libgl1-mesa-dev \
  mesa-common-dev

```
It is clearly that the order of the go_vncdriver README would be:
installation
   ...
Dependencies
 ...

**finally**:

> To figure out what happened, the easiest approach is to clone this window and run ./build.sh, which should print out the error upon installing with OpenGL:
> 
> git clone git@github.com:openai/go-vncdriver
> cd go-vncdriver
> ./build.sh
> Once you've fixed the issue, you should reinstall go-vncdriver via pip install --ignore-installed go-vncdriver.
> 