### PR TITLE
Use https remote url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ window and run `./build.sh`, which should print out the error upon
 installing with OpenGL:
 
 ```
-git clone git@github.com:openai/go-vncdriver
+git clone https://github.com/openai/go-vncdriver.git
 cd go-vncdriver
 ./build.sh
 ```


### PR DESCRIPTION
[Github recommends https URLs for cloning](https://help.github.com/articles/which-remote-url-should-i-use/). 
