### PR TITLE
Send Key and Pointer events in a single packet

### DIFF
--- a/vncclient/client.go
+++ b/vncclient/client.go
@@ -211,6 +211,8 @@ func (c *ClientConn) KeyEvent(keysym uint32, down bool) error {
 	c.send.Lock()
 	defer c.send.Unlock()
 
+    var buf bytes.Buffer
+
 	// TODO: buffer write?
 	var downFlag uint8
 	if down {
@@ -225,9 +227,13 @@ func (c *ClientConn) KeyEvent(keysym uint32, down bool) error {
 		keysym,
 	}
 	for _, val := range data {
-		if err := binary.Write(c.c, binary.BigEndian, val); err != nil {
+		if err := binary.Write(&buf, binary.BigEndian, val); err != nil {
 			return err
 		}
+	}
+
+    if _, err := c.c.Write(buf.Bytes()[0:8]); err != nil {
+		return err
 	}
 
 	return nil
@@ -244,6 +250,8 @@ func (c *ClientConn) PointerEvent(mask ButtonMask, x, y uint16) error {
 	c.send.Lock()
 	defer c.send.Unlock()
 
+    var buf bytes.Buffer
+
 	data := []interface{}{
 		uint8(5),
 		uint8(mask),
@@ -252,9 +260,13 @@ func (c *ClientConn) PointerEvent(mask ButtonMask, x, y uint16) error {
 	}
 
 	for _, val := range data {
-		if err := binary.Write(c.c, binary.BigEndian, val); err != nil {
+		if err := binary.Write(&buf, binary.BigEndian, val); err != nil {
 			return err
 		}
+	}
+
+    if _, err := c.c.Write(buf.Bytes()[0:6]); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
For KeyEvent and PointerEvent messages, it sends it as 4 packets (04) (00) (00) (00 00 00 60) in the example below for key 96. I was suspicious that this was causing Xvnc to get confused, but I couldn't demonstrate it. But it seems like a worthwhile performance optimization when running over the internet anyway.
```
02:24:35.257813 IP localhost.33927 > localhost.5900: Flags [P.], seq 215380:215381, ack 322802389, win 18935, options [nop,nop,TS val 26393028 ecr 26393028], length 1
    0x0034:  04
02:24:35.257821 IP localhost.33927 > localhost.5900: Flags [P.], seq 215381:215382, ack 322802389, win 18935, options [nop,nop,TS val 26393028 ecr 26393028], length 1
    0x0034:  00
02:24:35.257825 IP localhost.33927 > localhost.5900: Flags [P.], seq 215382:215383, ack 322802389, win 18935, options [nop,nop,TS val 26393028 ecr 26393028], length 1
    0x0034:  00
02:24:35.257833 IP localhost.33927 > localhost.5900: Flags [P.], seq 215383:215384, ack 322802389, win 18935, options [nop,nop,TS val 26393028 ecr 26393028], length 1
    0x0034:  00 
02:24:35.257837 IP localhost.33927 > localhost.5900: Flags [P.], seq 215384:215388, ack 322802389, win 18935, options [nop,nop,TS val 26393028 ecr 26393028], length 4
    0x0034:  0000 0060
```