### PR TITLE
Aliasing for github.com/op/go-logging

### DIFF
--- a/flexzlib/reader.go
+++ b/flexzlib/reader.go
@@ -7,7 +7,7 @@ import (
 	"hash/adler32"
 	"io"
 
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 	"github.com/openai/go-vncdriver/flexflate"
 )
 

--- a/gymvnc/gymvnc.go
+++ b/gymvnc/gymvnc.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 	"github.com/openai/go-vncdriver/vncclient"
 )
 

--- a/gymvnc/logging.go
+++ b/gymvnc/logging.go
@@ -3,7 +3,7 @@ package gymvnc
 import (
 	"os"
 
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 )
 
 func ConfigureLogging() {

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ import (
 	"unsafe"
 
 	"github.com/juju/errors"
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 	"github.com/openai/go-vncdriver/gymvnc"
 	"github.com/openai/go-vncdriver/vncclient"
 )

--- a/vncclient/encoding.go
+++ b/vncclient/encoding.go
@@ -8,7 +8,7 @@ import (
 	"io"
 
 	"github.com/juju/errors"
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 	"github.com/pixiv/go-libjpeg/jpeg"
 )
 

--- a/vncgl/vncgl.go
+++ b/vncgl/vncgl.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-gl/gl/v2.1/gl"
 	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/juju/errors"
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 	"github.com/openai/go-vncdriver/vncclient"
 )
 


### PR DESCRIPTION
Without it `goimports` tool gets confused and drops this dependency