### PR TITLE
transcode: fix unexpected EOF

### DIFF
--- a/cmd/transcode/main.go
+++ b/cmd/transcode/main.go
@@ -48,10 +48,7 @@ type fbsReader struct {
 
 func (r *fbsReader) read4() ([]byte, error) {
 	b := make([]byte, 4)
-	n, err := r.r.Read(b)
-	if n < 4 && err == nil {
-		err = io.ErrUnexpectedEOF
-	}
+	_, err := io.ReadFull(r.r, b)
 	return b, err
 }
 


### PR DESCRIPTION
We were throwing ErrUnexpectedEOF when Read didn't fill the 4 byte
buffer, but reading less than expected from bufio.Reader is OK!

From https://golang.org/pkg/io/#Reader

> If some data is available but not len(p) bytes, Read conventionally
> returns what is available instead of waiting for more.

We now use io.ReadFull