### PR TITLE
Modified README.md to reflect issues I was having on Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,17 @@ will fall back to installing without it.)
 To figure out what happened, the easiest approach is to clone this
 repo and run `./build.py`, which should print out the error upon
 installing with OpenGL:
-
 ```
 git clone https://github.com/openai/go-vncdriver.git
 cd go-vncdriver
 ./build.py
+```
+(NB if you're trying to compile for python 3.x
+and your python binary is called python3 you'll need to modify the 
+first line of build.py to the following otherwise the resulting
+.so file will only work with python 2.x
+```
+#!/usr/bin/env python3
 ```
 
 If you get errors like below then you need to install the [rendering dependencies](https://github.com/openai/go-vncdriver#rendering):


### PR DESCRIPTION
On Ubuntu 16.04 to install using python 3.5 you need to modify the setup.py otherwise you end up with a .so file which only works with python 2. I'm not a python expert so it took me a short while to figure this out - this small addition to the README might be helpful for others too.