### PR TITLE
Fix building on MacOS Sierra 10.12.4

### DIFF
--- a/build.py
+++ b/build.py
@@ -95,7 +95,7 @@ Build failed. HINT:
 ''')
 
     def build_gl():
-        cmd = 'go build -buildmode=c-shared -o go_vncdriver.so github.com/openai/go-vncdriver'
+        cmd = 'go build -ldflags=-s -buildmode=c-shared -o go_vncdriver.so github.com/openai/go-vncdriver'
         eprint('Building with OpenGL: GOPATH={} {}. (Set GO_VNCDRIVER_NOGL to build without OpenGL.)'.format(os.getenv('GOPATH'), cmd))
         return not subprocess.call(cmd.split())
 


### PR DESCRIPTION
This enables an ldflag fixing an issue in MacOS Sierra.

Ultimately, this will be fixed in upstream Go.

This fixes: https://github.com/openai/universe/issues/167

and is a manifestation of: https://github.com/golang/go/issues/19734.